### PR TITLE
getinvolved.html: string-length restriction added

### DIFF
--- a/partials/tabs/getinvolved.html
+++ b/partials/tabs/getinvolved.html
@@ -44,7 +44,7 @@
                    <img class="profile-img center" height="100" ng-src="https://avatars.githubusercontent.com/{{ member.login }}">
                    <div class="person-name">{{ member.name }}</div>
                    <div class="person-github-id">@{{member.login}}</div>
-                   <div class="person-github-bio"> {{member.bio }}</div>
+                   <div class="person-github-bio"> {{member.bio | limitTo:80}}{{member.bio.length > 80 ? '...' : ''}}</div>
                    <div class="center person-contributions-details">
                       <div class="row">
                         <div class="contribution-container">


### PR DESCRIPTION
getinvolved.html: String-length restricted to 30.

Earlier the member bio and his commit count collided as shown below - 
![capture](https://cloud.githubusercontent.com/assets/13695616/22620772/fe1a0c42-eb38-11e6-8566-3b6f3f55a076.JPG)

But after the changes it now looks like - 
![capture1](https://cloud.githubusercontent.com/assets/13695616/22620788/37be29ec-eb39-11e6-9821-76927bda678d.JPG)


Closes https://github.com/coala/landing-frontend/issues/108