### PR TITLE
style.css: Remove max width from modal elements

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -576,6 +576,9 @@ a:hover > .card{
   line-height: 2em;
   font-weight: 400;
 }
+.profile, .dashboard{
+  max-width: none !important;
+}
 @media (max-width: 768px) {
   .title {
       font-size: 6em;


### PR DESCRIPTION
Materialize adds default max width to the
container which is not required

![screen shot 2017-02-05 at 4 06 21 am](https://cloud.githubusercontent.com/assets/13018570/22622152/19a4289c-eb59-11e6-823e-c4ef3da0b851.png)