### PR TITLE
partials/tabs/home.html: use href instead of tc.setTab

### DIFF
--- a/partials/tabs/home.html
+++ b/partials/tabs/home.html
@@ -115,7 +115,7 @@ $ venv\scripts\activate  # On Windows
                     <div btf-markdown ng-include="'data/snippets/' + sc.snip[sc.lang_selected]" class="card card-content"></div>
                     <p>
                         Need more powerful analysis?
-                        <a ng-click="tc.setTab('/languages')">
+                        <a href="https://coala.io/languages/">
                             Check the available bears!
                         </a>
                     </p>


### PR DESCRIPTION
Change underline tab indicator position
when user click 'Check the available bears!'

Closes https://github.com/coala/landing-frontend/issues/164