### PR TITLE
Links below title are now shown properly in mobile view

### DIFF
--- a/vendors/materialize/css/materialize.css
+++ b/vendors/materialize/css/materialize.css
@@ -5581,7 +5581,8 @@ button.btn-floating {
   border-radius: 16px;
   background-color: #e4e4e4;
   margin-bottom: 5px;
-  margin-right: 5px;
+  margin-right: -40px;
+  margin-left: -40px;
 }
 
 .chip img {


### PR DESCRIPTION
changed the margin-right form 5px to -30 px

Closes #85