### PR TITLE
Links below title are not proper in mobile view #85

### DIFF
--- a/vendors/materialize/css/materialize.css
+++ b/vendors/materialize/css/materialize.css
@@ -5582,6 +5582,7 @@ button.btn-floating {
   background-color: #e4e4e4;
   margin-bottom: 5px;
   margin-right: 5px;
+  width: max-content;
 }
 
 .chip img {


### PR DESCRIPTION
added width: max-content; since class chip used only these places
closes https://github.com/coala/landing-frontend/issues/85

